### PR TITLE
Add yubikey-touch-detector as part of home-manager modules

### DIFF
--- a/home-manager/default.nix
+++ b/home-manager/default.nix
@@ -1,0 +1,7 @@
+{ ... }:
+
+{
+  imports = [
+    ./yubikey-touch-detector.nix
+  ];
+}

--- a/home-manager/yubikey-touch-detector.nix
+++ b/home-manager/yubikey-touch-detector.nix
@@ -25,14 +25,19 @@ in
   config = mkIf cfg.enable {
     home.packages = with pkgs; [ cfg.package ];
     systemd.user.services.yubikey-touch-detector = {
-      Unit = { Description = "Yubikey touch detector daemon"; After = [ "graphical.target" ]; };
+      Unit = {
+        Description = "Yubikey touch detector daemon";
+        After = [ "default.target" ];
+      };
       Service = {
         ExecStart = "${cfg.package}/bin/yubikey-touch-detector";
         Environment = cfg.environment ++ [
           "PATH=${pkgs.gnupg}/bin"
         ];
       };
-      Install = { WantedBy = [ "default.target" ]; };
+      Install = {
+        WantedBy = [ "default.target" ];
+      };
     };
     systemd.user.sockets.yubikey-touch-detector = {
       Unit = { Description = "Socket for yubikey touch detector daemon"; };
@@ -40,7 +45,9 @@ in
         ListenStream = "%t/yubikey-touch-detector.socket";
         RemoveOnStop = "yes";
       };
-      Install = { WantedBy = [ "sockets.target" ]; };
+      Install = {
+        WantedBy = [ "sockets.target" ];
+      };
     };
   };
 }

--- a/home-manager/yubikey-touch-detector.nix
+++ b/home-manager/yubikey-touch-detector.nix
@@ -1,0 +1,46 @@
+{ pkgs, lib, config, ... }:
+let
+  inherit (lib) mkEnableOption mkIf mkOption types;
+
+  cfg = config.services.yubikey-touch-detector;
+in
+{
+  options.services.yubikey-touch-detector = {
+    enable = mkEnableOption "Enable yubikey-touch-detector support";
+    package = mkOption {
+      type = types.package;
+      description = "Package to use for yubikey-touch-detector";
+      example = "nur.repos.mic92.yubikey-touch-detector";
+    };
+    environment = mkOption {
+      type = types.listOf types.str;
+      description = "Environment for yubikey-touch-detector systemd unit";
+      default = [
+        "YUBIKEY_TOUCH_DETECTOR_VERBOSE=true"
+        "YUBIKEY_TOUCH_DETECTOR_LIBNOTIFY=true"
+      ];
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = with pkgs; [ cfg.package ];
+    systemd.user.services.yubikey-touch-detector = {
+      Unit = { Description = "Yubikey touch detector daemon"; After = [ "graphical.target" ]; };
+      Service = {
+        ExecStart = "${cfg.package}/bin/yubikey-touch-detector";
+        Environment = cfg.environment ++ [
+          "PATH=${pkgs.gnupg}/bin"
+        ];
+      };
+      Install = { WantedBy = [ "default.target" ]; };
+    };
+    systemd.user.sockets.yubikey-touch-detector = {
+      Unit = { Description = "Socket for yubikey touch detector daemon"; };
+      Socket = {
+        ListenStream = "%t/yubikey-touch-detector.socket";
+        RemoveOnStop = "yes";
+      };
+      Install = { WantedBy = [ "sockets.target" ]; };
+    };
+  };
+}


### PR DESCRIPTION
This PR adds a `home-manager` directory to be imported from your home-manager config. More modules can be added to this directory and imported from the `default.nix`.

This also adds the `yubikey-touch-detector` module which sets up a systemd service and socket.  nixpkgs does not currently have a package for this so it requires you to specify the package to use (NUR has it).