### PR TITLE
Fix wpa_supplicant systemd unit name

### DIFF
--- a/features/wireguard.nix
+++ b/features/wireguard.nix
@@ -119,7 +119,7 @@ in
 
       wireguard-wg0 = { after = [ "physical-netns.service" ]; };
 
-      wpa_supplicant = {
+      "wpa_supplicant-${cfg.wirelessInterface}" = {
         after = lib.mkForce [ "physical-netns.service" ];
         requires = lib.mkForce [ "physical-netns.service" ];
         serviceConfig = { NetworkNamespacePath = "/var/run/netns/physical"; };


### PR DESCRIPTION
This seems to have been updated in nixos since Feb 2021. This ensures that the wpa_supplicant unit gets the correct options added.